### PR TITLE
cma 3.2.2 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cma" %}
-{% set version = "3.3.0" %}
+{% set version = "3.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,22 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b748b8e03f4e7ae816157d7b9bb2fc6b1fb2fee1d5fd3399329b646bb75861ec
+  sha256: 47ac71ddd2b9a922daa601516064a585a1a3dbbae7802bca935db25e525547eb
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - numpy
+    - wheel
+    - setuptools
   run:
-    - python >=3.6
+    - python
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ about:
   license_file: LICENSE
   summary: CMA-ES, Covariance Matrix Adaptation Evolution Strategy for non-linear numerical optimization in Python
   doc_url: http://cma.gforge.inria.fr/apidocs-pycma/
+  dev_url: https://github.com/CMA-ES/pycma
   description: |
     The Covariance Matrix Adaptation Evolution Strategy (CMA-ES) is a stochastic derivative-free numerical 
     optimization algorithm for difficult (non-convex, ill-conditioned, multi-modal, rugged, noisy) optimization

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - pip
     - python
-    - numpy
     - wheel
     - setuptools
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - cma.utilities
   commands:
     - pip check
+    - python -m cma.test -h
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,10 @@ test:
   imports:
     - cma
     - cma.utilities
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/CMA-ES/pycma
@@ -36,7 +40,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: CMA-ES, Covariance Matrix Adaptation Evolution Strategy for non-linear numerical optimization in Python
-  doc_url: http://cma.gforge.inria.fr/apidocs-pycma/
+  doc_url: https://cma-es.github.io/apidocs-pycma/
   dev_url: https://github.com/CMA-ES/pycma
   description: |
     The Covariance Matrix Adaptation Evolution Strategy (CMA-ES) is a stochastic derivative-free numerical 


### PR DESCRIPTION
cma 3.2.2 ❄️ 

**Destination channel:** Snowflake

### Links

- [PKG-4426](https://anaconda.atlassian.net/browse/PKG-4426) 
- [Upstream repository](https://github.com/CMA-ES/pycma)
- [Upstream changelog/diff](https://github.com/CMA-ES/pycma/compare/r3.2.2...r3.3.0)

### Explanation of changes:

- bump version
- updated SHA
- added script flags
- added skip for py3.6
- removed python specific pinnings
- added host requirements
- added test commands and requires
- added dev_url
- updated doc_url


[PKG-4426]: https://anaconda.atlassian.net/browse/PKG-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ